### PR TITLE
netmiko.exceptions

### DIFF
--- a/plugins/modules/ale_aos_command.py
+++ b/plugins/modules/ale_aos_command.py
@@ -25,7 +25,7 @@
 #                              anything the license permits.
 #
 
-from netmiko.ssh_exception import *
+from netmiko.exceptions import *
 from netmiko import ConnectHandler
 from ansible.module_utils.basic import AnsibleModule
 ANSIBLE_METADATA = {'metadata_version': '1.2',
@@ -42,7 +42,7 @@ description:
     - Connect to an OmniSwitch device and send a list of commands.
     It can search for a string.
 requirements:
-    - netmiko >= 3.4.0
+    - netmiko >= 4.0.0
 options:
     host:
         description:

--- a/plugins/modules/ale_aos_config.py
+++ b/plugins/modules/ale_aos_config.py
@@ -28,7 +28,7 @@
 from difflib import Differ
 from pathlib import Path
 from datetime import datetime
-from netmiko.ssh_exception import *
+from netmiko.exceptions import *
 from netmiko import ConnectHandler
 from ansible.module_utils.basic import AnsibleModule
 ANSIBLE_METADATA = {'metadata_version': '1.2',
@@ -45,7 +45,7 @@ description:
     - Connect to an OmniSwitch device and send configurations commands.
       It can take commands from a file or a commands list.
 requirements:
-    - netmiko >= 3.4.0
+    - netmiko >= 4.0.0
 options:
     host:
         description:

--- a/plugins/modules/ale_aos_facts.py
+++ b/plugins/modules/ale_aos_facts.py
@@ -25,7 +25,7 @@
 #                              anything the license permits.
 #
 
-from netmiko.ssh_exception import *
+from netmiko.exceptions import *
 from netmiko import ConnectHandler
 from ansible.module_utils.basic import AnsibleModule
 from re import findall
@@ -43,7 +43,7 @@ description:
     - Get device informations using getters selector and return a
       dictionary formatted output.
 requirements:
-    - netmiko >= 3.4.0
+    - netmiko >= 4.0.0
 options:
     host:
         description:

--- a/plugins/modules/ale_aos_ping.py
+++ b/plugins/modules/ale_aos_ping.py
@@ -25,7 +25,7 @@
 #                              anything the license permits.
 #
 
-from netmiko.ssh_exception import *
+from netmiko.exceptions import *
 from netmiko import ConnectHandler
 from ansible.module_utils.basic import AnsibleModule
 ANSIBLE_METADATA = {'metadata_version': '1.2',
@@ -42,7 +42,7 @@ description:
     - Try to connect to an OmniSwitch device. The module checks to see is the
       check_string is present in the output returned by find_prompt().
 requirements:
-    - netmiko >= 3.4.0
+    - netmiko >= 4.0.0
 options:
     host:
         description:


### PR DESCRIPTION
Deprecation of netmiko.ssh_exception, moved to sub library netmiko.exceptions

Tested against Netmiko 4.1.2
